### PR TITLE
Fix jpeglib.h file not found error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ stamp-h1
 Doxyfile
 doxygen-doc/
 INSTALL
+
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ target_compile_definitions(jp2a PUBLIC
 )
 
 find_package(JPEG REQUIRED)
+target_include_directories(jp2a PUBLIC ${JPEG_INCLUDE_DIR})
 target_link_libraries(jp2a ${JPEG_LIBRARIES})
+
 find_package(PNG REQUIRED)
+target_include_directories(jp2a PUBLIC ${PNG_INCLUDE_DIR})
 target_link_libraries(jp2a ${PNG_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.12)
 
+project(jp2a
+    VERSION 1.1.1
+)
+
 set(jp2a_source
     src/aspect_ratio.c
     src/curl.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.12)
+
 set(jp2a_source
     src/aspect_ratio.c
     src/curl.c


### PR DESCRIPTION
## 概要

Apple M2 Macbookの環境で、jp2aを静的ライブラリとしてビルドする際に`jpeglib.h file not found`となるエラーがありました。
このPRでは、libjpeg/libpngのincludeディレクトリを追加することで解決します。

他にも、CMakeのビルド時に出ていたWarningを修正しました。

```
$ cmake -S . -B build
CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- The C compiler identification is AppleClang 14.0.0.14000029
-- The CXX compiler identification is AppleClang 14.0.0.14000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found JPEG: /opt/homebrew/lib/libjpeg.dylib (found version "80")
-- Found ZLIB: /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/lib/libz.tbd (found version "1.2.11")
-- Found PNG: /opt/homebrew/lib/libpng.dylib (found version "1.6.39")
CMake Warning (dev) in CMakeLists.txt:
  No cmake_minimum_required command is present.  A line of code such as

    cmake_minimum_required(VERSION 3.24)

  should be added at the top of the file.  The version specified may be lower
  if you wish to support older CMake versions for this project.  For more
  information run "cmake --help-policy CMP0000".
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done
-- Generating done
-- Build files have been written to: /Users/hiroya/ghq/github.com/Hiroya-W/jp2a/build

$ cmake --build build
[ 12%] Building C object CMakeFiles/jp2a.dir/src/aspect_ratio.o
[ 25%] Building C object CMakeFiles/jp2a.dir/src/curl.o
[ 37%] Building C object CMakeFiles/jp2a.dir/src/html.o
[ 50%] Building C object CMakeFiles/jp2a.dir/src/image.o
/Users/hiroya/ghq/github.com/Hiroya-W/jp2a/src/image.c:20:10: fatal error: 'jpeglib.h' file not found
#include "jpeglib.h"
         ^~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/jp2a.dir/src/image.o] Error 1
make[1]: *** [CMakeFiles/jp2a.dir/all] Error 2
make: *** [all] Error 2
```