### PR TITLE
Refactoring CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,39 +6,12 @@ project(jp2a
     LANGUAGES C
 )
 
-set(jp2a_source
-    src/aspect_ratio.c
-    src/curl.c
-    src/html.c
-    src/image.c
-    src/jp2a.c
-    src/options.c
-    src/terminal.c
-)
-
 if(WIN32)
     set(WIN32_MACROS "WIN32")
 endif(WIN32)
 
-file(TOUCH ${CMAKE_BINARY_DIR}/config.h)
-
-add_library(jp2a STATIC ${jp2a_source})
-target_include_directories(jp2a PUBLIC include ${CMAKE_BINARY_DIR})
-target_compile_definitions(jp2a PUBLIC
-    ${WIN32_MACROS}
-    NDEBUG
-    _CONSOLE
-    PACKAGE_STRING="jp2a 1.1.1-whofetch"
-    PACKAGE_URL="https://github.com/mass-0910/jp2a"
-    PACKAGE_BUGREPORT="https://github.com/mass-0910/jp2a/issues"
-    HAVE_STRING_H
-    HAVE_STDLIB_H
-)
-
 find_package(JPEG REQUIRED)
-target_include_directories(jp2a PUBLIC ${JPEG_INCLUDE_DIR})
-target_link_libraries(jp2a ${JPEG_LIBRARIES})
-
 find_package(PNG REQUIRED)
-target_include_directories(jp2a PUBLIC ${PNG_INCLUDE_DIR})
-target_link_libraries(jp2a ${PNG_LIBRARIES})
+
+file(TOUCH ${CMAKE_BINARY_DIR}/config.h)
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ project(jp2a
     LANGUAGES C
 )
 
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+    message(FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")
+endif()
+
 if(WIN32)
     set(WIN32_MACROS "WIN32")
 endif(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(jp2a
     VERSION 1.1.1
+    DESCRIPTION "Converts jpg/png images to ASCII"
+    LANGUAGES C
 )
 
 set(jp2a_source

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,18 @@ target_sources(jp2a PRIVATE
     terminal.c
 )
 
-target_include_directories(jp2a PUBLIC include ${CMAKE_BINARY_DIR})
+target_include_directories(jp2a PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR} # for config.h
+    ${JPEG_INCLUDE_DIR}
+    ${PNG_INCLUDE_DIR}
+)
+
+target_link_libraries(jp2a
+    ${JPEG_LIBRARIES}
+    ${PNG_LIBRARIES}
+)
+
 target_compile_definitions(jp2a PUBLIC
     ${WIN32_MACROS}
     NDEBUG
@@ -21,9 +32,3 @@ target_compile_definitions(jp2a PUBLIC
     HAVE_STRING_H
     HAVE_STDLIB_H
 )
-
-target_include_directories(jp2a PUBLIC ${JPEG_INCLUDE_DIR})
-target_link_libraries(jp2a ${JPEG_LIBRARIES})
-
-target_include_directories(jp2a PUBLIC ${PNG_INCLUDE_DIR})
-target_link_libraries(jp2a ${PNG_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(jp2a_source
+add_library(jp2a STATIC)
+
+target_sources(jp2a PRIVATE
     aspect_ratio.c
     curl.c
     html.c
@@ -7,8 +9,6 @@ set(jp2a_source
     options.c
     terminal.c
 )
-
-add_library(jp2a STATIC ${jp2a_source})
 
 target_include_directories(jp2a PUBLIC include ${CMAKE_BINARY_DIR})
 target_compile_definitions(jp2a PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(jp2a_source
+    aspect_ratio.c
+    curl.c
+    html.c
+    image.c
+    jp2a.c
+    options.c
+    terminal.c
+)
+
+add_library(jp2a STATIC ${jp2a_source})
+
+target_include_directories(jp2a PUBLIC include ${CMAKE_BINARY_DIR})
+target_compile_definitions(jp2a PUBLIC
+    ${WIN32_MACROS}
+    NDEBUG
+    _CONSOLE
+    PACKAGE_STRING="jp2a 1.1.1-whofetch"
+    PACKAGE_URL="https://github.com/mass-0910/jp2a"
+    PACKAGE_BUGREPORT="https://github.com/mass-0910/jp2a/issues"
+    HAVE_STRING_H
+    HAVE_STDLIB_H
+)
+
+target_include_directories(jp2a PUBLIC ${JPEG_INCLUDE_DIR})
+target_link_libraries(jp2a ${JPEG_LIBRARIES})
+
+target_include_directories(jp2a PUBLIC ${PNG_INCLUDE_DIR})
+target_link_libraries(jp2a ${PNG_LIBRARIES})


### PR DESCRIPTION
## 概要

以下の項目で、`CMakeLists.txt`のリファクタリングを行いました。

- プロジェクトルートに置かれた`CMakeLitsts.txt`を`src/CMakeLists.txt`と分離
- 使える部分はCMakeの機能を使う(`target_sources`)
- `target_include_directories`や`target_link_libraries`を1つに統合